### PR TITLE
Bump library version to 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,23 @@ Instrument your apps with Aptabase, an Open Source, Privacy-First and, Simple An
 
 ## Setup
 
-Add the dependency below to your module's `build.gradle.kts` file:
+Add the JitPack repository in `settings.gradle.kts` file:
 
 ```kotlin
-    implementation("com.aptabase:aptabase:0.0.6")
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://www.jitpack.io") } // JitPack repository
+    }
+}
+```
+
+Add the dependency to your module-level `build.gradle.kts` file:
+
+```kotlin
+    implementation("com.github.aptabase:aptabase-kotlin:0.0.7")
 ```
 
 If you don't already have an `Application` class, create one. Then, initialize the Aptabase object inside your application class:

--- a/aptabase/build.gradle
+++ b/aptabase/build.gradle
@@ -50,7 +50,7 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.release
                 groupId = 'com.aptabase'
-                artifactId = 'Aptabase-Android'
+                artifactId = 'aptabase-kotlin'
                 version = '0.0.7'
             }
         }

--- a/aptabase/build.gradle
+++ b/aptabase/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-    id "com.vanniktech.maven.publish" version "0.27.0"
+    id 'maven-publish'
 }
 
 android {
@@ -42,4 +42,17 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId = 'com.aptabase'
+                artifactId = 'Aptabase-Android'
+                version = '0.0.7'
+            }
+        }
+    }
 }

--- a/aptabase/src/main/java/com/aptabase/Aptabase.kt
+++ b/aptabase/src/main/java/com/aptabase/Aptabase.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.Executors
 data class InitOptions(val host: String? = null)
 
 class Aptabase private constructor() {
-  private val SDK_VERSION = "aptabase-kotlin@0.0.6"
+  private val SDK_VERSION = "aptabase-kotlin@0.0.7"
   private val SESSION_TIMEOUT: Long = TimeUnit.HOURS.toMillis(1)
   private var appKey: String? = null
   private var sessionId = UUID.randomUUID()

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 rootProject.name = "Aptabase"


### PR DESCRIPTION
### IMPORTANT

* The value of `sdkVersion` property sent to server is changed to `aptabase-kotlin@0.0.7`
* A release with tag `0.0.7` should be published immediately after merging the PR to avoid issues since the updated instructions refer to version `0.0.7`