### PR TITLE
Fix JitPack build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
 Add the dependency to your module-level `build.gradle.kts` file:
 
 ```kotlin
-    implementation("com.github.aptabase:aptabase-kotlin:0.0.7")
+    implementation("com.github.aptabase:aptabase-kotlin:0.0.8")
 ```
 
 If you don't already have an `Application` class, create one. Then, initialize the Aptabase object inside your application class:

--- a/aptabase/build.gradle
+++ b/aptabase/build.gradle
@@ -25,11 +25,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 
@@ -49,9 +49,9 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-                groupId = 'com.aptabase'
+                groupId = 'com.github.aptabase'
                 artifactId = 'aptabase-kotlin'
-                version = '0.0.7'
+                version = '0.0.8'
             }
         }
     }

--- a/aptabase/src/main/java/com/aptabase/Aptabase.kt
+++ b/aptabase/src/main/java/com/aptabase/Aptabase.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.Executors
 data class InitOptions(val host: String? = null)
 
 class Aptabase private constructor() {
-  private val SDK_VERSION = "aptabase-kotlin@0.0.7"
+  private val SDK_VERSION = "aptabase-kotlin@0.0.8"
   private val SESSION_TIMEOUT: Long = TimeUnit.HOURS.toMillis(1)
   private var appKey: String? = null
   private var sessionId = UUID.randomUUID()

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
* Update JAVA to version `17` to fix library compatibility
* Override JitPack default settings to use JDK version `17`
* Changed library's `groupId` to follow the official documentation's naming convention
* Bump lib version to `0.0.8`
* Bump SDK version to `aptabase-kotlin@0.0.8`
* Update Readme file to reflect the new dependency version

I have tested the new configuration under my own fork to make sure it works. You can see the success log [here](https://jitpack.io/com/github/roozbehzarei/aptabase-kotlin/0.0.9/build.log).

Please remove the `0.0.7` release from github as it has build issues. And sorry for ruining `0.0.7`.