### PR TITLE
Added version to init options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dependencyResolutionManagement {
 Add the dependency to your module-level `build.gradle.kts` file:
 
 ```kotlin
-    implementation("com.github.aptabase:aptabase-kotlin:0.0.8")
+    implementation("com.github.aptabase:aptabase-kotlin:0.0.9")
 ```
 
 If you don't already have an `Application` class, create one. Then, initialize the Aptabase object inside your application class:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ class MyApplication : Application() {
 }
 ```
 
+You can also pass options to customize behavior:
+
+```kotlin
+Aptabase.instance.initialize(applicationContext, APTABASE_KEY, InitOptions(
+    host = "https://your-self-hosted-instance.com",  // For self-hosted Aptabase
+    trackingMode = TrackingMode.asRelease,            // Force release mode
+    appVersion = "2.0.0"                              // Override the app version
+))
+```
+
+- `host` — Custom server URL for self-hosted Aptabase instances (required for `A-SH-*` app keys)
+- `trackingMode` — `TrackingMode.readFromEnvironment` (default), `TrackingMode.asDebug`, or `TrackingMode.asRelease`
+- `appVersion` — Override the app version reported with events (default: read from the app package info)
+
 To get your `App Key`, you can find it inside `Instructions` tab from the left side menu of the Aptabase website.
 
 ## Usage

--- a/aptabase/build.gradle
+++ b/aptabase/build.gradle
@@ -48,7 +48,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.aptabase'
                 artifactId = 'aptabase-kotlin'
-                version = '0.0.8'
+                version = '0.0.9'
             }
         }
     }

--- a/aptabase/src/main/java/com/aptabase/Aptabase.kt
+++ b/aptabase/src/main/java/com/aptabase/Aptabase.kt
@@ -17,7 +17,11 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.Executors
 
-data class InitOptions(val host: String? = null)
+data class InitOptions(
+    val host: String? = null,
+    val trackingMode: TrackingMode = TrackingMode.readFromEnvironment,
+    val appVersion: String? = null
+)
 
 class Aptabase private constructor() {
   private val SDK_VERSION = "aptabase-kotlin@0.0.8"
@@ -53,6 +57,12 @@ class Aptabase private constructor() {
     apiURL = getApiUrl(parts[1], opts)
     this.appKey = appKey
     env = EnvironmentInfo.get(context)
+
+    if (opts?.trackingMode != null && opts.trackingMode != TrackingMode.readFromEnvironment) {
+      env?.isDebug = opts.trackingMode == TrackingMode.asDebug
+    }
+
+    opts?.appVersion?.let { env?.appVersion = it }
   }
 
   fun trackEvent(eventName: String, props: Map<String, Any> = emptyMap<String, Any>()) {

--- a/aptabase/src/main/java/com/aptabase/Aptabase.kt
+++ b/aptabase/src/main/java/com/aptabase/Aptabase.kt
@@ -24,7 +24,7 @@ data class InitOptions(
 )
 
 class Aptabase private constructor() {
-  private val SDK_VERSION = "aptabase-kotlin@0.0.8"
+  private val SDK_VERSION = "aptabase-kotlin@0.0.9"
   private val SESSION_TIMEOUT: Long = TimeUnit.HOURS.toMillis(1)
   private var appKey: String? = null
   private var sessionId = UUID.randomUUID()

--- a/aptabase/src/main/java/com/aptabase/TrackingMode.kt
+++ b/aptabase/src/main/java/com/aptabase/TrackingMode.kt
@@ -1,0 +1,14 @@
+package com.aptabase
+
+/**
+ * Represents the tracking mode (release/debug) for the client.
+ *
+ * - [asDebug]: Track events as debug events.
+ * - [asRelease]: Track events as release events.
+ * - [readFromEnvironment]: Detect automatically from the app's build flags (default).
+ */
+enum class TrackingMode {
+    asDebug,
+    asRelease,
+    readFromEnvironment
+}

--- a/llms.txt
+++ b/llms.txt
@@ -50,13 +50,17 @@ class MyApplication : Application() {
 }
 ```
 
-For self-hosted instances, pass `InitOptions`:
+Pass `InitOptions` to customize behavior:
 
 ```kotlin
 Aptabase.instance.initialize(
     applicationContext,
     "A-SH-1234567890",
-    InitOptions(host = "https://your-self-hosted-instance.com")
+    InitOptions(
+        host = "https://your-self-hosted-instance.com",  // For self-hosted Aptabase
+        trackingMode = TrackingMode.asRelease,            // Force release mode
+        appVersion = "2.0.0"                              // Override the app version
+    )
 )
 ```
 
@@ -87,7 +91,9 @@ Aptabase.instance.trackEvent("purchase_completed",
 
 ## Configuration
 
-- `InitOptions(host: String?)` — set `host` for self-hosted Aptabase instances. Required when using `A-SH-*` app keys.
+- `host` — Custom server URL for self-hosted Aptabase instances. Required when using `A-SH-*` app keys.
+- `trackingMode` — `TrackingMode.readFromEnvironment` (default), `TrackingMode.asDebug`, or `TrackingMode.asRelease`
+- `appVersion` — Override the app version reported with events (default: read from app package info)
 - Sessions auto-rotate after 1 hour of inactivity.
 - Events are dispatched on a background thread pool (5 threads).
 
@@ -96,7 +102,7 @@ Aptabase.instance.trackEvent("purchase_completed",
 - Android only (uses `android.content.Context` for initialization)
 - Requires an `Application` subclass for initialization
 - Uses `HttpURLConnection` for network requests (no external HTTP dependencies)
-- Debug mode is detected automatically from `ApplicationInfo.FLAG_DEBUGGABLE`
+- Debug mode is detected automatically from `ApplicationInfo.FLAG_DEBUGGABLE` (overridable via `trackingMode`)
 - Collects only: OS version, locale, app version, build number, device model
 
 ## Cross-Discovery

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 > Open-source, privacy-first analytics SDK for Android apps. GDPR-compliant, no cookies, no personal data collection.
 
 Package: `com.github.aptabase:aptabase-kotlin`
-Install: `implementation("com.github.aptabase:aptabase-kotlin:0.0.8")`
+Install: `implementation("com.github.aptabase:aptabase-kotlin:0.0.9")`
 Repo: https://github.com/aptabase/aptabase-kotlin
 
 ## Overview
@@ -34,7 +34,7 @@ dependencyResolutionManagement {
 Add the dependency in your module-level `build.gradle.kts`:
 
 ```kotlin
-implementation("com.github.aptabase:aptabase-kotlin:0.0.8")
+implementation("com.github.aptabase:aptabase-kotlin:0.0.9")
 ```
 
 ## Initialization


### PR DESCRIPTION
Just like in this request: https://github.com/aptabase/aptabase-swift/pull/36

I have added the ability to adjust the value of the build number, so while the app is still in version 1, it is pretty bad for beta and alpha version testing, so ideally I want to be able to force my own app version to over-write the 1.0 build.